### PR TITLE
Set a name for the scene's main node

### DIFF
--- a/addons/material-design-icons/icon_finder/IconsGrid.tscn
+++ b/addons/material-design-icons/icon_finder/IconsGrid.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://addons/material-design-icons/fonts/24.tres" type="DynamicFont" id=1]
 
-[node name="" type="GridContainer"]
+[node name="IconsGrid" type="GridContainer"]
 margin_right = 990.0
 columns = 24
 


### PR DESCRIPTION
Prevents a `name == ""` error to continuously appear in the console